### PR TITLE
Support CSS standalone file

### DIFF
--- a/src/ViteManifest.php
+++ b/src/ViteManifest.php
@@ -155,20 +155,22 @@ class ViteManifest implements ViteManifestInterface
 
     /**
      * Fetches and returns all style files for the specified entry points,
-     * unless dev server is enabled, in which case no style are required.
+     * unless dev server is enabled, in which case only standalone entries are returned.
      *
      * @param string ...$entries
      *
-     * @throws JsonException               If manifest can't be read
+     * @return string[] Path to each style files
      * @throws EntrypointNotFoundException If an entry point is not found in the manifest.
      *
-     * @return string[] Path to each style files
+     * @throws JsonException               If manifest can't be read
      */
     public function getStyles(string ...$entries): array
     {
-        // Server. Returns nothing.
+        // Server. Return standalone entries + server;
         if ($this->useServer()) {
-            return [];
+            $stylesheets = array_merge(['@vite/client'], $entries);
+
+            return $this->prefixFiles($stylesheets);
         }
 
         // Default behavior
@@ -263,6 +265,11 @@ class ViteManifest implements ViteManifestInterface
 
         // Return container
         $files = [];
+
+        // Entry point's output is a standalone css file
+        if (str_ends_with($chunk['file'], '.css')) {
+            $files[] = $chunk['file'];
+        }
 
         // Add entry point chunk's css list
         if (array_key_exists('css', $chunk)) {

--- a/src/ViteManifest.php
+++ b/src/ViteManifest.php
@@ -166,9 +166,9 @@ class ViteManifest implements ViteManifestInterface
      */
     public function getStyles(string ...$entries): array
     {
-        // Server. Return standalone entries + server;
+        // Server. Return standalone entries;
         if ($this->useServer()) {
-            $stylesheets = array_merge(['@vite/client'], $entries);
+            $stylesheets = array_merge($entries);
 
             return $this->prefixFiles($stylesheets);
         }

--- a/src/ViteManifest.php
+++ b/src/ViteManifest.php
@@ -168,7 +168,7 @@ class ViteManifest implements ViteManifestInterface
     {
         // Server. Return standalone entries;
         if ($this->useServer()) {
-            $stylesheets = array_filter($entries, fn($entry) => $this->isStylesheet($entry));
+            $stylesheets = array_filter($entries, fn ($entry) => $this->isStylesheet($entry));
 
             return $this->prefixFiles($stylesheets);
         }
@@ -267,7 +267,7 @@ class ViteManifest implements ViteManifestInterface
         $files = [];
 
         // Entry point's output is a standalone css file
-        if (str_ends_with($chunk['file'], '.css')) {
+        if (str_ends_with($chunk['file'] ?? '', '.css')) {
             $files[] = $chunk['file'];
         }
 
@@ -467,8 +467,17 @@ class ViteManifest implements ViteManifestInterface
         return $this->devEnabled;
     }
 
-    private function isStylesheet($filename): bool
+    /**
+     * Check if a file is a stylesheet.
+     *
+     * @param string $filename The filename to check
+     *
+     * @return bool
+     */
+    protected function isStylesheet(string $filename): bool
     {
-        return in_array(pathinfo($filename, PATHINFO_EXTENSION), ['css', 'less', 'scss', 'sass']);
+        $extensions = ['css', 'scss', 'sass', 'less'];
+
+        return in_array(pathinfo($filename, PATHINFO_EXTENSION), $extensions, true);
     }
 }

--- a/src/ViteManifest.php
+++ b/src/ViteManifest.php
@@ -159,10 +159,10 @@ class ViteManifest implements ViteManifestInterface
      *
      * @param string ...$entries
      *
-     * @return string[] Path to each style files
+     * @throws JsonException               If manifest can't be read
      * @throws EntrypointNotFoundException If an entry point is not found in the manifest.
      *
-     * @throws JsonException               If manifest can't be read
+     * @return string[] Path to each style files
      */
     public function getStyles(string ...$entries): array
     {

--- a/src/ViteManifest.php
+++ b/src/ViteManifest.php
@@ -469,6 +469,6 @@ class ViteManifest implements ViteManifestInterface
 
     private function isStylesheet($filename): bool
     {
-        return in_array(pathinfo($filename, PATHINFO_EXTENSION), ['css', 'less', 'scss']);
+        return in_array(pathinfo($filename, PATHINFO_EXTENSION), ['css', 'less', 'scss', 'sass']);
     }
 }

--- a/src/ViteManifest.php
+++ b/src/ViteManifest.php
@@ -168,7 +168,7 @@ class ViteManifest implements ViteManifestInterface
     {
         // Server. Return standalone entries;
         if ($this->useServer()) {
-            $stylesheets = array_merge($entries);
+            $stylesheets = array_filter($entries, fn($entry) => $this->isStylesheet($entry));
 
             return $this->prefixFiles($stylesheets);
         }
@@ -465,5 +465,10 @@ class ViteManifest implements ViteManifestInterface
     protected function useServer(): bool
     {
         return $this->devEnabled;
+    }
+
+    private function isStylesheet($filename): bool
+    {
+        return in_array(pathinfo($filename, PATHINFO_EXTENSION), ['css', 'less', 'scss']);
     }
 }

--- a/tests/ViteManifestTest.php
+++ b/tests/ViteManifestTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace UserFrosting\ViteTwig\Tests;
 
 use JsonException;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use UserFrosting\ViteTwig\Exceptions\EntrypointNotFoundException;
 use UserFrosting\ViteTwig\Exceptions\ManifestNotFoundException;
@@ -114,6 +115,16 @@ class ViteManifestTest extends TestCase
         ], $manifest->getStyles('views/foo.js', 'views/bar.js'));
     }
 
+    #[TestWith(['standalone.css', 'standalone-Dei2f1sT.css'])]
+    #[TestWith(['standalone.scss', 'standalone-ABC.css'])]
+    #[TestWith(['standalone.sass', 'standalone-BCD.css'])]
+    #[TestWith(['standalone.less', 'standalone-DEF.css'])]
+    public function testGetStylesWithStandaloneCSS(string $entry, string $expected): void
+    {
+        $manifest = new ViteManifest($this->manifestFile);
+        $this->assertSame([$expected], $manifest->getStyles($entry));
+    }
+
     public function testImports() :void
     {
         $manifest = new ViteManifest($this->manifestFile);
@@ -194,6 +205,20 @@ class ViteManifestTest extends TestCase
 
         $this->assertSame(['http://[::1]:3000/dist/@vite/client', 'http://[::1]:3000/dist/views/foo.js'], $manifest->getScripts('views/foo.js'));
         $this->assertSame(['http://[::1]:3000/dist/@vite/client', 'http://[::1]:3000/dist/views/foo.js', 'http://[::1]:3000/dist/views/bar.js'], $manifest->getScripts('views/foo.js', 'views/bar.js'));
+    }
+
+    #[TestWith(['standalone.css', 'http://[::1]:3000/standalone.css'])]
+    #[TestWith(['standalone.scss', 'http://[::1]:3000/standalone.scss'])]
+    #[TestWith(['standalone.less', 'http://[::1]:3000/standalone.less'])]
+    #[TestWith(['standalone.sass', 'http://[::1]:3000/standalone.sass'])]
+    public function testDevServerGetStylesWithStandaloneCSS(string $entry, string $expected): void
+    {
+        $manifest = new ViteManifest(
+            manifestPath: $this->manifestFile,
+            serverUrl: 'http://[::1]:3000/',
+            devEnabled: true,
+        );
+        $this->assertSame([$expected], $manifest->getStyles($entry));
     }
 
     public function testRenderScripts(): void

--- a/tests/manifests/manifest.json
+++ b/tests/manifests/manifest.json
@@ -1,33 +1,53 @@
 {
     "_shared-D5fCFa4Q.js": {
-      "file": "assets/shared-ChJ_j-JJ.css",
-      "src": "_shared-D5fCFa4Q.js"
+        "file": "assets/shared-ChJ_j-JJ.css",
+        "src": "_shared-D5fCFa4Q.js"
     },
     "_shared-B7PI925R.js": {
-      "file": "assets/shared-B7PI925R.js",
-      "name": "shared",
-      "css": ["assets/shared-ChJ_j-JJ.css"]
+        "file": "assets/shared-B7PI925R.js",
+        "name": "shared",
+        "css": ["assets/shared-ChJ_j-JJ.css"]
     },
     "baz.js": {
-      "file": "assets/baz-B2H3sXNv.js",
-      "name": "baz",
-      "src": "baz.js",
-      "isDynamicEntry": true
+        "file": "assets/baz-B2H3sXNv.js",
+        "name": "baz",
+        "src": "baz.js",
+        "isDynamicEntry": true
     },
     "views/bar.js": {
-      "file": "assets/bar-gkvgaI9m.js",
-      "name": "bar",
-      "src": "views/bar.js",
-      "isEntry": true,
-      "imports": ["_shared-B7PI925R.js"],
-      "dynamicImports": ["baz.js"]
+        "file": "assets/bar-gkvgaI9m.js",
+        "name": "bar",
+        "src": "views/bar.js",
+        "isEntry": true,
+        "imports": ["_shared-B7PI925R.js"],
+        "dynamicImports": ["baz.js"]
     },
     "views/foo.js": {
-      "file": "assets/foo-BRBmoGS9.js",
-      "name": "foo",
-      "src": "views/foo.js",
-      "isEntry": true,
-      "imports": ["_shared-B7PI925R.js"],
-      "css": ["assets/foo-5UjPuW-k.css"]
+        "file": "assets/foo-BRBmoGS9.js",
+        "name": "foo",
+        "src": "views/foo.js",
+        "isEntry": true,
+        "imports": ["_shared-B7PI925R.js"],
+        "css": ["assets/foo-5UjPuW-k.css"]
+    },
+    "standalone.css": {
+        "file": "standalone-Dei2f1sT.css",
+        "src": "standalone.css",
+        "isEntry": true
+    },
+    "standalone.scss": {
+        "file": "standalone-ABC.css",
+        "src": "standalone.scss",
+        "isEntry": true
+    },
+    "standalone.sass": {
+        "file": "standalone-BCD.css",
+        "src": "standalone.sass",
+        "isEntry": true
+    },
+    "standalone.less": {
+        "file": "standalone-DEF.css",
+        "src": "standalone.less",
+        "isEntry": true
     }
-  }
+}


### PR DESCRIPTION
Hi,

Thanks for your nice plugin. Here is a small use case I stumble upon while setup Vite in a project. I have SCSS files that are standalone (and simply attached to a page) which I convert by passing them to Vite who is kind enough to do the transformation without needed to attach it to a JS file.

I let you add necessary test, etc. especially as I'm not a PHP specialist.

And Happy New Year !